### PR TITLE
[humble-devel] add cpp and xml formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+...

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,7 +1,7 @@
 name: formatter
 
 on:
-  push:
+  pull_request:
 
 jobs:
   formatter:
@@ -20,16 +20,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format libxml2-utils
           python -m pip install --upgrade pip
           pip install autoflake black isort
+      - name: clang-format
+        run: find . -type f \( -name "*.cpp" -or -name "*.hpp" -or -name "*.h" \) -exec clang-format -i -style=file {} \;
+      - name: xmllint
+        run: find . -type f \( -name "*.xml" -or -name "*.launch" -or -name "*.xacro" \) -exec xmllint --format -o {} {} \;
       - name: autoflake
         run: find . -type f -name "*.py" -exec autoflake {} \;
-      - name: black
-        run: find . -type f -name "*.py" -exec black {} \;
+      - name: autopep8
+        run: find . -type f -name "*.py" -exec autopep8 -i {} \;
       - name: isort
         run: find . -type f -name "*.py" -exec isort {} \;
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: apply code formatter change
-          ref: ${{ github.head_ref }}
+          commit_message: apply format


### PR DESCRIPTION
- Replaced the Python code formatter black with `autopep8`.
- Introduced a new code formatting step for C++ files using `clang-format`.
- Introduced a new code formatting step for XML-related files using `xmllint`.
- Updates GitHub Actions to automatically format code whenever a new pull request is opened, synchronized, or reopened.