### PR TITLE
[melodic-devel] add cpp and xml formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+...

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,7 +1,7 @@
 name: formatter
 
 on:
-  push:
+  pull_request:
 
 jobs:
   formatter:
@@ -20,16 +20,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format libxml2-utils
           python -m pip install --upgrade pip
           pip install autoflake black isort
+      - name: clang-format
+        run: find . -type f \( -name "*.cpp" -or -name "*.hpp" -or -name "*.h" \) -exec clang-format -i -style=file {} \;
+      - name: xmllint
+        run: find . -type f \( -name "*.xml" -or -name "*.launch" -or -name "*.xacro" \) -exec xmllint --format -o {} {} \;
       - name: autoflake
         run: find . -type f -name "*.py" -exec autoflake {} \;
-      - name: black
-        run: find . -type f -name "*.py" -exec black {} \;
+      - name: autopep8
+        run: find . -type f -name "*.py" -exec autopep8 -i {} \;
       - name: isort
         run: find . -type f -name "*.py" -exec isort {} \;
       - name: auto commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: apply code formatter change
-          ref: ${{ github.head_ref }}
+          commit_message: apply format

--- a/include/predict_with_cloud_node/predict_with_cloud_node.h
+++ b/include/predict_with_cloud_node/predict_with_cloud_node.h
@@ -1,32 +1,33 @@
 #pragma once
 
-#include <ros/ros.h>
-#include <opencv2/opencv.hpp>
-#include <tf2_ros/transform_listener.h>
+#include <geometry_msgs/TransformStamped.h>
 #include <image_geometry/pinhole_camera_model.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/synchronizer.h>
 #include <pcl/common/common.h>
-#include <pcl/common/transforms.h>
 #include <pcl/common/pca.h>
+#include <pcl/common/transforms.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
+#include <pcl/segmentation/extract_clusters.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/transforms.h>
-#include <pcl/segmentation/extract_clusters.h>
+#include <ros/ros.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <geometry_msgs/TransformStamped.h>
 #include <std_msgs/Header.h>
+#include <tf2_ros/transform_listener.h>
 #include <vision_msgs/Detection2DArray.h>
-#include <vision_msgs/Detection3DArray.h>
 #include <vision_msgs/Detection3D.h>
+#include <vision_msgs/Detection3DArray.h>
 #include <vision_msgs/ObjectHypothesisWithPose.h>
-#include <visualization_msgs/MarkerArray.h>
 #include <visualization_msgs/Marker.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/approximate_time.h>
+#include <visualization_msgs/MarkerArray.h>
+
 #include <Eigen/Dense>
+#include <opencv2/opencv.hpp>
 
 class PredictWithCloudNode
 {
@@ -40,9 +41,9 @@ private:
   ros::Publisher _detection_cloud_pub;
   ros::Publisher _detection3d_pub;
   ros::Publisher _marker_pub;
-  typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::CameraInfo, sensor_msgs::PointCloud2,
-                                                          vision_msgs::Detection2DArray>
-      _sensor_fusion_sync_subs;
+  typedef message_filters::sync_policies::ApproximateTime<
+    sensor_msgs::CameraInfo, sensor_msgs::PointCloud2, vision_msgs::Detection2DArray>
+    _sensor_fusion_sync_subs;
   message_filters::Subscriber<sensor_msgs::CameraInfo> _camera_info_sub;
   message_filters::Subscriber<sensor_msgs::PointCloud2> _lidar_sub;
   message_filters::Subscriber<vision_msgs::Detection2DArray> _detection2d_sub;
@@ -56,17 +57,22 @@ private:
 
 public:
   PredictWithCloudNode();
-  void syncCallback(const sensor_msgs::CameraInfo::ConstPtr& camera_info_msg,
-                    const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
-                    const vision_msgs::Detection2DArrayConstPtr& detections2d_msg);
-  pcl::PointCloud<pcl::PointXYZ> msg2TransformedCloud(const sensor_msgs::PointCloud2ConstPtr cloud_msg);
-  std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2>
-  projectCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud,
-               const vision_msgs::Detection2DArrayConstPtr detections2d_msg, const std_msgs::Header header);
-  pcl::PointCloud<pcl::PointXYZ> cloud2TransformedCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud,
-                                                        const std_msgs::Header header);
-  pcl::PointCloud<pcl::PointXYZ> euclideanClusterExtraction(const pcl::PointCloud<pcl::PointXYZ> cloud);
-  void createBoundingBox(vision_msgs::Detection3DArray& detections3d_msg, const pcl::PointCloud<pcl::PointXYZ> cloud,
-                         const std::vector<vision_msgs::ObjectHypothesisWithPose> detections_results);
-  visualization_msgs::MarkerArray createMarkerArray(const vision_msgs::Detection3DArray& detections3d_msg);
+  void syncCallback(
+    const sensor_msgs::CameraInfo::ConstPtr & camera_info_msg,
+    const sensor_msgs::PointCloud2ConstPtr & cloud_msg,
+    const vision_msgs::Detection2DArrayConstPtr & detections2d_msg);
+  pcl::PointCloud<pcl::PointXYZ> msg2TransformedCloud(
+    const sensor_msgs::PointCloud2ConstPtr cloud_msg);
+  std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2> projectCloud(
+    const pcl::PointCloud<pcl::PointXYZ> & cloud,
+    const vision_msgs::Detection2DArrayConstPtr detections2d_msg, const std_msgs::Header header);
+  pcl::PointCloud<pcl::PointXYZ> cloud2TransformedCloud(
+    const pcl::PointCloud<pcl::PointXYZ> & cloud, const std_msgs::Header header);
+  pcl::PointCloud<pcl::PointXYZ> euclideanClusterExtraction(
+    const pcl::PointCloud<pcl::PointXYZ> cloud);
+  void createBoundingBox(
+    vision_msgs::Detection3DArray & detections3d_msg, const pcl::PointCloud<pcl::PointXYZ> cloud,
+    const std::vector<vision_msgs::ObjectHypothesisWithPose> detections_results);
+  visualization_msgs::MarkerArray createMarkerArray(
+    const vision_msgs::Detection3DArray & detections3d_msg);
 };

--- a/src/predict_with_cloud_node.cpp
+++ b/src/predict_with_cloud_node.cpp
@@ -15,16 +15,19 @@ PredictWithCloudNode::PredictWithCloudNode() : _pnh("~")
   _detection_cloud_pub = _nh.advertise<sensor_msgs::PointCloud2>("detection_cloud", 1);
   _detection3d_pub = _nh.advertise<vision_msgs::Detection3DArray>(_detection3d_topic, 1);
   _marker_pub = _nh.advertise<visualization_msgs::MarkerArray>("detection_marker", 1);
-  _sensor_fusion_sync = boost::make_shared<message_filters::Synchronizer<_sensor_fusion_sync_subs>>(10);
+  _sensor_fusion_sync =
+    boost::make_shared<message_filters::Synchronizer<_sensor_fusion_sync_subs>>(10);
   _sensor_fusion_sync->connectInput(_camera_info_sub, _lidar_sub, _detection2d_sub);
-  _sensor_fusion_sync->registerCallback(boost::bind(&PredictWithCloudNode::syncCallback, this, _1, _2, _3));
+  _sensor_fusion_sync->registerCallback(
+    boost::bind(&PredictWithCloudNode::syncCallback, this, _1, _2, _3));
   _tf_buffer.reset(new tf2_ros::Buffer(ros::Duration(2.0), true));
   _tf_listener.reset(new tf2_ros::TransformListener(*_tf_buffer));
 }
 
-void PredictWithCloudNode::syncCallback(const sensor_msgs::CameraInfo::ConstPtr& camera_info_msg,
-                                        const sensor_msgs::PointCloud2ConstPtr& cloud_msg,
-                                        const vision_msgs::Detection2DArrayConstPtr& detections2d_msg)
+void PredictWithCloudNode::syncCallback(
+  const sensor_msgs::CameraInfo::ConstPtr & camera_info_msg,
+  const sensor_msgs::PointCloud2ConstPtr & cloud_msg,
+  const vision_msgs::Detection2DArrayConstPtr & detections2d_msg)
 {
   pcl::PointCloud<pcl::PointXYZ> transformed_cloud;
   vision_msgs::Detection3DArray detections3d_msg;
@@ -36,7 +39,7 @@ void PredictWithCloudNode::syncCallback(const sensor_msgs::CameraInfo::ConstPtr&
   transformed_cloud = msg2TransformedCloud(cloud_msg);
 
   std::tie(detections3d_msg, detection_cloud_msg) =
-      projectCloud(transformed_cloud, detections2d_msg, cloud_msg->header);
+    projectCloud(transformed_cloud, detections2d_msg, cloud_msg->header);
 
   marker_array_msg = createMarkerArray(detections3d_msg);
 
@@ -45,29 +48,29 @@ void PredictWithCloudNode::syncCallback(const sensor_msgs::CameraInfo::ConstPtr&
   _marker_pub.publish(marker_array_msg);
 }
 
-pcl::PointCloud<pcl::PointXYZ>
-PredictWithCloudNode::msg2TransformedCloud(const sensor_msgs::PointCloud2ConstPtr cloud_msg)
+pcl::PointCloud<pcl::PointXYZ> PredictWithCloudNode::msg2TransformedCloud(
+  const sensor_msgs::PointCloud2ConstPtr cloud_msg)
 {
   pcl::PointCloud<pcl::PointXYZ> cloud;
   pcl::PointCloud<pcl::PointXYZ> transformed_cloud;
   sensor_msgs::PointCloud2 transformed_cloud_msg;
   geometry_msgs::TransformStamped tf;
-  try
-  {
-    tf = _tf_buffer->lookupTransform(_cam_model.tfFrame(), cloud_msg->header.frame_id, cloud_msg->header.stamp);
-    pcl_ros::transformPointCloud(_cam_model.tfFrame(), tf.transform, *cloud_msg, transformed_cloud_msg);
+  try {
+    tf = _tf_buffer->lookupTransform(
+      _cam_model.tfFrame(), cloud_msg->header.frame_id, cloud_msg->header.stamp);
+    pcl_ros::transformPointCloud(
+      _cam_model.tfFrame(), tf.transform, *cloud_msg, transformed_cloud_msg);
     pcl::fromROSMsg(transformed_cloud_msg, transformed_cloud);
-  }
-  catch (tf2::TransformException& e)
-  {
+  } catch (tf2::TransformException & e) {
     ROS_WARN("%s", e.what());
   }
   return transformed_cloud;
 }
 
-std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2> PredictWithCloudNode::projectCloud(
-    const pcl::PointCloud<pcl::PointXYZ>& cloud, const vision_msgs::Detection2DArrayConstPtr detections2d_msg,
-    const std_msgs::Header header)
+std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2>
+PredictWithCloudNode::projectCloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud,
+  const vision_msgs::Detection2DArrayConstPtr detections2d_msg, const std_msgs::Header header)
 {
   pcl::PointCloud<pcl::PointXYZ> detection_cloud_raw;
   pcl::PointCloud<pcl::PointXYZ> detection_cloud;
@@ -76,28 +79,31 @@ std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2> PredictWithC
   vision_msgs::Detection3DArray detections3d_msg;
   sensor_msgs::PointCloud2 combine_detection_cloud_msg;
   detections3d_msg.header = header;
-  for (size_t i = 0; i < detections2d_msg->detections.size(); i++)
-  {
-    for (const auto& point : cloud.points)
-    {
+  for (size_t i = 0; i < detections2d_msg->detections.size(); i++) {
+    for (const auto & point : cloud.points) {
       cv::Point3d pt_cv(point.x, point.y, point.z);
       cv::Point2d uv = _cam_model.project3dToPixel(pt_cv);
-      if (point.z > 0 && uv.x > 0 &&
-          uv.x >= detections2d_msg->detections[i].bbox.center.x - detections2d_msg->detections[i].bbox.size_x / 2 &&
-          uv.x <= detections2d_msg->detections[i].bbox.center.x + detections2d_msg->detections[i].bbox.size_x / 2 &&
-          uv.y >= detections2d_msg->detections[i].bbox.center.y - detections2d_msg->detections[i].bbox.size_y / 2 &&
-          uv.y <= detections2d_msg->detections[i].bbox.center.y + detections2d_msg->detections[i].bbox.size_y / 2)
-      {
+      if (
+        point.z > 0 && uv.x > 0 &&
+        uv.x >= detections2d_msg->detections[i].bbox.center.x -
+                  detections2d_msg->detections[i].bbox.size_x / 2 &&
+        uv.x <= detections2d_msg->detections[i].bbox.center.x +
+                  detections2d_msg->detections[i].bbox.size_x / 2 &&
+        uv.y >= detections2d_msg->detections[i].bbox.center.y -
+                  detections2d_msg->detections[i].bbox.size_y / 2 &&
+        uv.y <= detections2d_msg->detections[i].bbox.center.y +
+                  detections2d_msg->detections[i].bbox.size_y / 2) {
         detection_cloud_raw.points.push_back(point);
       }
     }
     detection_cloud = cloud2TransformedCloud(detection_cloud_raw, header);
-    if (!detection_cloud.points.empty())
-    {
+    if (!detection_cloud.points.empty()) {
       closest_detection_cloud = euclideanClusterExtraction(detection_cloud);
-      createBoundingBox(detections3d_msg, closest_detection_cloud, detections2d_msg->detections[i].results);
-      combine_detection_cloud.insert(combine_detection_cloud.end(), closest_detection_cloud.begin(),
-                                     closest_detection_cloud.end());
+      createBoundingBox(
+        detections3d_msg, closest_detection_cloud, detections2d_msg->detections[i].results);
+      combine_detection_cloud.insert(
+        combine_detection_cloud.end(), closest_detection_cloud.begin(),
+        closest_detection_cloud.end());
       detection_cloud_raw.points.clear();
     }
   }
@@ -106,25 +112,22 @@ std::tuple<vision_msgs::Detection3DArray, sensor_msgs::PointCloud2> PredictWithC
   return std::forward_as_tuple(detections3d_msg, combine_detection_cloud_msg);
 }
 
-pcl::PointCloud<pcl::PointXYZ> PredictWithCloudNode::cloud2TransformedCloud(const pcl::PointCloud<pcl::PointXYZ>& cloud,
-                                                                            const std_msgs::Header header)
+pcl::PointCloud<pcl::PointXYZ> PredictWithCloudNode::cloud2TransformedCloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, const std_msgs::Header header)
 {
   pcl::PointCloud<pcl::PointXYZ> transformed_cloud;
   geometry_msgs::TransformStamped tf;
-  try
-  {
+  try {
     tf = _tf_buffer->lookupTransform(header.frame_id, _cam_model.tfFrame(), header.stamp);
     pcl_ros::transformPointCloud(cloud, transformed_cloud, tf.transform);
-  }
-  catch (tf2::TransformException& e)
-  {
+  } catch (tf2::TransformException & e) {
     ROS_WARN("%s", e.what());
   }
   return transformed_cloud;
 }
 
-pcl::PointCloud<pcl::PointXYZ>
-PredictWithCloudNode::euclideanClusterExtraction(const pcl::PointCloud<pcl::PointXYZ> cloud)
+pcl::PointCloud<pcl::PointXYZ> PredictWithCloudNode::euclideanClusterExtraction(
+  const pcl::PointCloud<pcl::PointXYZ> cloud)
 {
   pcl::PointCloud<pcl::PointXYZ> closest_cluster;
   pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
@@ -138,18 +141,17 @@ PredictWithCloudNode::euclideanClusterExtraction(const pcl::PointCloud<pcl::Poin
   ec.setMaxClusterSize(_max_cluster_size);
   ec.setSearchMethod(tree);
   ec.extract(cluster_indices);
-  for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin(); it != cluster_indices.end(); ++it)
-  {
+  for (std::vector<pcl::PointIndices>::const_iterator it = cluster_indices.begin();
+       it != cluster_indices.end(); ++it) {
     pcl::PointCloud<pcl::PointXYZ> cloud_cluster;
     Eigen::Vector4f centroid;
-    for (std::vector<int>::const_iterator pit = it->indices.begin(); pit != it->indices.end(); ++pit)
-    {
+    for (std::vector<int>::const_iterator pit = it->indices.begin(); pit != it->indices.end();
+         ++pit) {
       cloud_cluster.points.push_back(cloud.points[*pit]);
     }
     pcl::compute3DCentroid(cloud_cluster, centroid);
     float distance = centroid.norm();
-    if (distance < min_distance)
-    {
+    if (distance < min_distance) {
       min_distance = distance;
       closest_cluster = cloud_cluster;
     }
@@ -158,8 +160,8 @@ PredictWithCloudNode::euclideanClusterExtraction(const pcl::PointCloud<pcl::Poin
 }
 
 void PredictWithCloudNode::createBoundingBox(
-    vision_msgs::Detection3DArray& detections3d_msg, const pcl::PointCloud<pcl::PointXYZ> cloud,
-    const std::vector<vision_msgs::ObjectHypothesisWithPose> detections_results)
+  vision_msgs::Detection3DArray & detections3d_msg, const pcl::PointCloud<pcl::PointXYZ> cloud,
+  const std::vector<vision_msgs::ObjectHypothesisWithPose> detections_results)
 {
   vision_msgs::Detection3D detection3d;
   pcl::PointCloud<pcl::PointXYZ> transformed_cloud;
@@ -174,8 +176,8 @@ void PredictWithCloudNode::createBoundingBox(
   transform.rotate(Eigen::AngleAxisf(theta, Eigen::Vector3f::UnitZ()));
   pcl::transformPointCloud(cloud, transformed_cloud, transform);
   pcl::getMinMax3D(transformed_cloud, min_pt, max_pt);
-  transformed_bbox_center =
-      Eigen::Vector4f((min_pt.x + max_pt.x) / 2, (min_pt.y + max_pt.y) / 2, (min_pt.z + max_pt.z) / 2, 1);
+  transformed_bbox_center = Eigen::Vector4f(
+    (min_pt.x + max_pt.x) / 2, (min_pt.y + max_pt.y) / 2, (min_pt.z + max_pt.z) / 2, 1);
   bbox_center = transform.inverse() * transformed_bbox_center;
   detection3d.bbox.center.position.x = bbox_center[0];
   detection3d.bbox.center.position.y = bbox_center[1];
@@ -192,16 +194,15 @@ void PredictWithCloudNode::createBoundingBox(
   detections3d_msg.detections.push_back(detection3d);
 }
 
-visualization_msgs::MarkerArray
-PredictWithCloudNode::createMarkerArray(const vision_msgs::Detection3DArray& detections3d_msg)
+visualization_msgs::MarkerArray PredictWithCloudNode::createMarkerArray(
+  const vision_msgs::Detection3DArray & detections3d_msg)
 {
   visualization_msgs::MarkerArray marker_array;
-  for (size_t i = 0; i < detections3d_msg.detections.size(); i++)
-  {
-    if (std::isfinite(detections3d_msg.detections[i].bbox.size.x) &&
-        std::isfinite(detections3d_msg.detections[i].bbox.size.y) &&
-        std::isfinite(detections3d_msg.detections[i].bbox.size.z))
-    {
+  for (size_t i = 0; i < detections3d_msg.detections.size(); i++) {
+    if (
+      std::isfinite(detections3d_msg.detections[i].bbox.size.x) &&
+      std::isfinite(detections3d_msg.detections[i].bbox.size.y) &&
+      std::isfinite(detections3d_msg.detections[i].bbox.size.z)) {
       visualization_msgs::Marker marker;
       marker.header = detections3d_msg.header;
       marker.ns = "detection";
@@ -223,7 +224,7 @@ PredictWithCloudNode::createMarkerArray(const vision_msgs::Detection3DArray& det
   return marker_array;
 }
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
   ros::init(argc, argv, "predict_with_cloud_node");
   PredictWithCloudNode node;


### PR DESCRIPTION
- Replaced the Python code formatter black with `autopep8`.
- Introduced a new code formatting step for C++ files using `clang-format`.
- Introduced a new code formatting step for XML-related files using `xmllint`.
- Updates GitHub Actions to automatically format code whenever a new pull request is opened, synchronized, or reopened.