### PR TITLE
[melodic-devel] add rm -rf /opt/hostedtoolcache

### DIFF
--- a/.github/workflows/docker-build-check-bot.yml
+++ b/.github/workflows/docker-build-check-bot.yml
@@ -24,9 +24,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: build and push
+      - name: build check
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ultralytics_ros:melodic
+          push: false

--- a/.github/workflows/docker-build-check-bot.yml
+++ b/.github/workflows/docker-build-check-bot.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: prune Docker Images
+        run: docker image prune --force
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -26,4 +28,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: false
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ultralytics_ros:melodic

--- a/.github/workflows/docker-build-check-bot.yml
+++ b/.github/workflows/docker-build-check-bot.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - name: prune Docker Images
-        run: docker image prune --force
+      - name: delete unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/docker-deploy-bot.yml
+++ b/.github/workflows/docker-deploy-bot.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: delete unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       - name: checkout
         uses: actions/checkout@v2
       - name: set up QEMU

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ultralytics_ros [![ROS-melodic Docker Build Check](https://github.com/Alpaca-zip/ultralytics_ros/actions/workflows/docker-build-check-bot.yml/badge.svg?branch=melodic-devel&event=pull_request)](https://github.com/Alpaca-zip/ultralytics_ros/actions/workflows/docker-build-check-bot.yml)
+# ultralytics_ros [![ROS-melodic Docker Build Check](https://github.com/Alpaca-zip/ultralytics_ros/actions/workflows/docker-build-check-bot.yml/badge.svg?event=pull_request)](https://github.com/Alpaca-zip/ultralytics_ros/actions/workflows/docker-build-check-bot.yml)
 ROS package for real-time object detection using the Ultralytics YOLO, enabling flexible integration with various robotics applications.
 
 <img src="https://github.com/Alpaca-zip/ultralytics_ros/assets/84959376/9da7dbbf-5cc0-41bc-be82-d481abbf552a" width="800px">


### PR DESCRIPTION
The issue with GitHub Actions continuously running docker build is that it results in a `no space left on device` error. To address this, I've added `rm -rf /opt/hostedtoolcache` at the beginning of the workflow.

Related discussions : https://github.com/orgs/community/discussions/25678