### PR TITLE
[humble-devel] fix bug for colcon_ws not existing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use tiryoh/ros2-desktop-vnc:humble as the base image
-FROM tiryoh/ros2-desktop-vnc:humble
+FROM tiryoh/ros2-desktop-vnc:humble-20230611T1926
 
 # Set Environment Variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Change to use `tiryoh/ros2-desktop-vnc:humble-20230611T1926` created before June 17, 2023 and fix the following issues.
- fix #27 