### PR TITLE
Add YOLO-World Model Support in tracker_node.py

### DIFF
--- a/script/tracker_node.py
+++ b/script/tracker_node.py
@@ -47,7 +47,13 @@ class TrackerNode:
         self.result_boxes = rospy.get_param("~result_boxes", True)
         path = roslib.packages.get_pkg_dir("ultralytics_ros")
         self.model = YOLO(f"{path}/models/{yolo_model}")
-        self.model.fuse()
+        use_world = "world" in yolo_model.lower()
+        if use_world:
+            if self.classes is not None:
+                self.model.set_classes(self.classes)
+            self.classes = None
+        else:
+            self.model.fuse()
         self.sub = rospy.Subscriber(
             self.input_topic,
             Image,

--- a/src/tracker_with_cloud_node.cpp
+++ b/src/tracker_with_cloud_node.cpp
@@ -53,6 +53,8 @@ void TrackerWithCloudNode::syncCallback(const sensor_msgs::CameraInfo::ConstPtr&
   pcl::PointCloud<pcl::PointXYZ>::Ptr downsampled_cloud(new pcl::PointCloud<pcl::PointXYZ>);
   downsampled_cloud = downsampleCloudMsg(cloud_msg);
 
+  cam_model_.fromCameraInfo(camera_info_msg);
+  
   pcl::PointCloud<pcl::PointXYZ>::Ptr transformed_cloud;
   transformed_cloud = cloud2TransformedCloud(downsampled_cloud, cloud_msg->header.frame_id, cam_model_.tfFrame(),
                                              cloud_msg->header.stamp);
@@ -60,7 +62,6 @@ void TrackerWithCloudNode::syncCallback(const sensor_msgs::CameraInfo::ConstPtr&
   sensor_msgs::PointCloud2 detection_cloud_msg;
   visualization_msgs::MarkerArray marker_array_msg;
 
-  cam_model_.fromCameraInfo(camera_info_msg);
   projectCloud(transformed_cloud, yolo_result_msg, cloud_msg->header, detections3d_msg, detection_cloud_msg);
   marker_array_msg = createMarkerArray(detections3d_msg, callback_interval.toSec());
 


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [x] Feature

## Overview
- Added support for YOLO-World model in tracker_node.py.
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- Introduced `use_world` variable to check if the YOLO model name contains "world".
- When using YOLO-World model, if `self.classes` is defined, it sets these classes in the model and then resets `self.classes` to `None`.
- Otherwise, retains existing `self.model.fuse()` invocation.
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [x] I have tested this change with rosbag
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->
