### PR TITLE
add support for CompressedImage

### DIFF
--- a/script/tracker_node.py
+++ b/script/tracker_node.py
@@ -20,9 +20,10 @@
 import cv_bridge
 import numpy as np
 import rclpy
+import time
 from ament_index_python.packages import get_package_share_directory
 from rclpy.node import Node
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, CompressedImage
 from ultralytics import YOLO
 from vision_msgs.msg import Detection2D, Detection2DArray, ObjectHypothesisWithPose
 from ultralytics_ros.msg import YoloResult
@@ -65,19 +66,41 @@ class TrackerNode(Node):
         result_image_topic = (
             self.get_parameter("result_image_topic").get_parameter_value().string_value
         )
-        self.create_subscription(Image, input_topic, self.image_callback, 1)
+
+        im_topic_type = self.wait_for_topic_type(input_topic, timeout=5.0)
+        if im_topic_type == 'sensor_msgs/msg/CompressedImage':
+            self.create_subscription(CompressedImage, input_topic, self.compressed_image_callback, 1)
+        elif im_topic_type == 'sensor_msgs/msg/Image':
+            self.create_subscription(Image, input_topic, self.image_callback, 1)
+        else:
+            self.get_logger().error(f"Unsupported image topic type: {im_topic_type}")
+            raise ValueError(f"Unsupported image topic type: {im_topic_type}")
+
         self.results_pub = self.create_publisher(YoloResult, result_topic, 1)
         self.result_image_pub = self.create_publisher(Image, result_image_topic, 1)
 
+    def wait_for_topic_type(self, topic_name, timeout=5.0):     
+        start_time = time.time()
+        while (time.time() - start_time) < timeout:
+            for name, types in self.get_topic_names_and_types():
+                if name == topic_name:
+                    return types[0]
+            time.sleep(0.1)
+        return ''
+
     def image_callback(self, msg):
         cv_image = self.bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+        self.process_im(cv_image, msg.header)
 
+    def compressed_image_callback(self, msg):
+        cv_image = self.bridge.compressed_imgmsg_to_cv2(msg, desired_encoding="bgr8")
+        self.process_im(cv_image, msg.header)
+
+    def process_im(self, cv_image, header):
         conf_thres = self.get_parameter("conf_thres").get_parameter_value().double_value
         iou_thres = self.get_parameter("iou_thres").get_parameter_value().double_value
         max_det = self.get_parameter("max_det").get_parameter_value().integer_value
-        classes = (
-            self.get_parameter("classes").get_parameter_value().integer_array_value
-        )
+        classes = self.get_parameter("classes").get_parameter_value().integer_array_value
         tracker = self.get_parameter("tracker").get_parameter_value().string_value
         device = self.get_parameter("device").get_parameter_value().string_value or None
         results = self.model.track(
@@ -95,8 +118,8 @@ class TrackerNode(Node):
         if results is not None:
             yolo_result_msg = YoloResult()
             yolo_result_image_msg = Image()
-            yolo_result_msg.header = msg.header
-            yolo_result_image_msg.header = msg.header
+            yolo_result_msg.header = header
+            yolo_result_image_msg.header = header
             yolo_result_msg.detections = self.create_detections_array(results)
             yolo_result_image_msg = self.create_result_image(results)
             if self.use_segmentation:

--- a/src/tracker_with_cloud_node.cpp
+++ b/src/tracker_with_cloud_node.cpp
@@ -35,7 +35,7 @@ TrackerWithCloudNode::TrackerWithCloudNode() : rclcpp::Node("tracker_with_cloud_
   camera_info_sub_.subscribe(this, camera_info_topic_);
   lidar_sub_.subscribe(this, lidar_topic_);
   yolo_result_sub_.subscribe(this, yolo_result_topic_);
-  sync_ = std::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy>>(5);
+  sync_ = std::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy>>(30);
   sync_->connectInput(camera_info_sub_, lidar_sub_, yolo_result_sub_);
   sync_->registerCallback(std::bind(&TrackerWithCloudNode::syncCallback, this, std::placeholders::_1,
                                     std::placeholders::_2, std::placeholders::_3));
@@ -329,7 +329,7 @@ TrackerWithCloudNode::createMarkerArray(const vision_msgs::msg::Detection3DArray
       marker_msg.color.g = 1.0;
       marker_msg.color.b = 0.0;
       marker_msg.color.a = 0.5;
-      marker_msg.lifetime = rclcpp::Duration(std::chrono::duration<double>(duration));
+      marker_msg.lifetime = rclcpp::Duration(std::chrono::duration<double>(std::max(duration * 2.0, 0.2)));
       marker_array_msg.markers.push_back(marker_msg);
     }
   }

--- a/src/tracker_with_cloud_node.cpp
+++ b/src/tracker_with_cloud_node.cpp
@@ -35,7 +35,7 @@ TrackerWithCloudNode::TrackerWithCloudNode() : rclcpp::Node("tracker_with_cloud_
   camera_info_sub_.subscribe(this, camera_info_topic_);
   lidar_sub_.subscribe(this, lidar_topic_);
   yolo_result_sub_.subscribe(this, yolo_result_topic_);
-  sync_ = std::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy>>(1);
+  sync_ = std::make_shared<message_filters::Synchronizer<ApproximateSyncPolicy>>(5);
   sync_->connectInput(camera_info_sub_, lidar_sub_, yolo_result_sub_);
   sync_->registerCallback(std::bind(&TrackerWithCloudNode::syncCallback, this, std::placeholders::_1,
                                     std::placeholders::_2, std::placeholders::_3));


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [X] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- Added support for `sensor_msgs/msg/CompressedImage` to the tracker node.
<!--
Brief summary of the changes made in this PR.
-->

## Detail
- The node now dynamically checks the image input topic type, and if it is a CompressedImage, it uses compressed_imgmsg_to_cv2 for decoding instead of imgmsg_to_cv2. 
<!--
In-depth description of the changes, especially if the changes are significant or complex.
-->

## Test
- [X] I have tested this change both in Gazebo Simulator and with a live camera stream providing CompressedImage data.
- [X] Checked that YOLO detections and result image publishing work correctly for both image types.
<!--
what was done to ensure it works.
Example:
- [ ] I have tested this change with gazebo
- [ ] I have tested this change with rosbag
-->

## Attention
- Currently supports `sensor_msgs/msg/CompressedImage` and `sensor_msgs/msg/Image` types.
<!--
Any particular attention or caution the reviewers should have regarding the PR.
-->
